### PR TITLE
Add 2 DC routers and connect them with BGP VPN

### DIFF
--- a/frr-bgp-vpn-multisite/Vagrantfile
+++ b/frr-bgp-vpn-multisite/Vagrantfile
@@ -138,7 +138,16 @@ EOF
                 exit 1
             fi
         SHELL
-    
+
+        dc2gw.vm.provision "shell", inline: <<-SHELL
+            sudo vtysh -c "show ip bgp summary"
+            sudo vtysh -c "show ip bgp neighbors [neighbor IP]"
+            sudo vtysh -c "show ip bgp neighbors [neighbor IP] advertised-routes"
+            sudo vtysh -c "show ip bgp neighbors [neighbor IP] received-routes"
+            sudo vtysh -c "show running-config"
+            sudo vtysh -c "show ip route"
+        SHELL
+
     end
   end
   

--- a/frr-bgp-vpn-multisite/Vagrantfile
+++ b/frr-bgp-vpn-multisite/Vagrantfile
@@ -1,10 +1,20 @@
+
+RAM = 1000
+VCPUS = 2
+
 Vagrant.configure("2") do |config|
-    # Configure router1
-    config.vm.define "router1" do |router1|
-        router1.vm.box = "generic/ubuntu2204"
-        router1.vm.network "private_network", ip: "192.168.56.10"
-        router1.vm.hostname = "router1"
-        router1.vm.provision "shell", inline: <<-SHELL
+
+    vm_memory = ENV['VM_MEMORY'] || RAM
+    vm_cpus = ENV['VM_CPUS'] || VCPUS
+
+
+
+    # Configure dc1gw
+    config.vm.define "dc1gw" do |dc1gw|
+        dc1gw.vm.box = "generic/ubuntu2204"
+        dc1gw.vm.network "private_network", ip: "192.168.56.10"
+        dc1gw.vm.hostname = "dc1gw"
+        dc1gw.vm.provision "shell", inline: <<-SHELL
         # Disable systemd-resolved and set static DNS
         sudo systemctl disable systemd-resolved
         sudo systemctl stop systemd-resolved
@@ -18,30 +28,42 @@ Vagrant.configure("2") do |config|
         echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
         SHELL
     
-        # router1.vm.synced_folder "./config/router1/etc/frr", "/etc/frr"
+        # dc1gw.vm.synced_folder "./config/dc1gw/etc/frr", "/etc/frr"
     
-        router1.vm.provision "shell", inline: <<-SHELL
+        dc1gw.vm.provision "shell", inline: <<-SHELL
+
+            # add dummy route for testing
+            sudo ip route add 192.168.99.0/24 dev eth0
 
             sudo tee /etc/frr/frr.conf <<EOF
 !
 frr version 8.1
 frr defaults traditional
-hostname router1
+hostname dc1gw
 log syslog informational
 no ipv6 forwarding
 service integrated-vtysh-config
+!
+debug bgp neighbor-events
+debug bgp updates in
+debug bgp updates out
 !
 router bgp 65001
     bgp router-id 192.168.56.10
     neighbor 192.168.56.11 remote-as 65002
     !
     address-family ipv4 unicast
-    network 192.168.56.0/24
-    neighbor 192.168.56.11 soft-reconfiguration inbound
+        network 192.168.56.0/24
+        network 192.168.99.0/24
+        neighbor 192.168.56.11 soft-reconfiguration inbound
+        neighbor 192.168.56.11 route-map ALLOW_ALL in
+        neighbor 192.168.56.11 route-map ALLOW_ALL out
     exit-address-family
 exit
 !
-end
+route-map ALLOW_ALL permit 10
+exit
+!
 EOF
 
             # Enable BGPD and restart FRR
@@ -57,12 +79,12 @@ EOF
     end
   
   
-    # Configure router2
-    config.vm.define "router2" do |router2|
-        router2.vm.box = "generic/ubuntu2204"
-        router2.vm.network "private_network", ip: "192.168.56.11"
-        router2.vm.hostname = "router2"
-        router2.vm.provision "shell", inline: <<-SHELL
+    # Configure dc2gw
+    config.vm.define "dc2gw" do |dc2gw|
+        dc2gw.vm.box = "generic/ubuntu2204"
+        dc2gw.vm.network "private_network", ip: "192.168.56.11"
+        dc2gw.vm.hostname = "dc2gw"
+        dc2gw.vm.provision "shell", inline: <<-SHELL
         # Disable systemd-resolved and set static DNS
         sudo systemctl disable systemd-resolved
         sudo systemctl stop systemd-resolved
@@ -76,15 +98,15 @@ EOF
         echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
         SHELL
     
-        # router1.vm.synced_folder "./config/router1/etc/frr", "/etc/frr"
+        # dc1gw.vm.synced_folder "./config/dc1gw/etc/frr", "/etc/frr"
     
-        router2.vm.provision "shell", inline: <<-SHELL
+        dc2gw.vm.provision "shell", inline: <<-SHELL
 
             sudo tee /etc/frr/frr.conf <<EOF
 !
 frr version 8.1
 frr defaults traditional
-hostname router2
+hostname dc2gw
 log syslog informational
 no ipv6 forwarding
 service integrated-vtysh-config
@@ -94,9 +116,14 @@ router bgp 65002
     neighbor 192.168.56.10 remote-as 65001
     !
     address-family ipv4 unicast
-    network 192.168.56.0/24
-    neighbor 192.168.56.10 soft-reconfiguration inbound
+        network 192.168.56.0/24
+        neighbor 192.168.56.10 soft-reconfiguration inbound
+        neighbor 192.168.56.10 route-map ALLOW_ALL in
+        neighbor 192.168.56.10 route-map ALLOW_ALL out
     exit-address-family
+exit
+!
+route-map ALLOW_ALL permit 10
 exit
 !
 end

--- a/frr-bgp-vpn-multisite/Vagrantfile
+++ b/frr-bgp-vpn-multisite/Vagrantfile
@@ -1,0 +1,117 @@
+Vagrant.configure("2") do |config|
+    # Configure router1
+    config.vm.define "router1" do |router1|
+        router1.vm.box = "generic/ubuntu2204"
+        router1.vm.network "private_network", ip: "192.168.56.10"
+        router1.vm.hostname = "router1"
+        router1.vm.provision "shell", inline: <<-SHELL
+        # Disable systemd-resolved and set static DNS
+        sudo systemctl disable systemd-resolved
+        sudo systemctl stop systemd-resolved
+        sudo rm /etc/resolv.conf
+        echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+    
+        # Install FRR
+        sudo apt-get update
+        sudo apt-get install -y frr frr-doc
+        sudo sysctl -w net.ipv4.ip_forward=1
+        echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
+        SHELL
+    
+        # router1.vm.synced_folder "./config/router1/etc/frr", "/etc/frr"
+    
+        router1.vm.provision "shell", inline: <<-SHELL
+
+            sudo tee /etc/frr/frr.conf <<EOF
+!
+frr version 8.1
+frr defaults traditional
+hostname router1
+log syslog informational
+no ipv6 forwarding
+service integrated-vtysh-config
+!
+router bgp 65001
+    bgp router-id 192.168.56.10
+    neighbor 192.168.56.11 remote-as 65002
+    !
+    address-family ipv4 unicast
+    network 192.168.56.0/24
+    neighbor 192.168.56.11 soft-reconfiguration inbound
+    exit-address-family
+exit
+!
+end
+EOF
+
+            # Enable BGPD and restart FRR
+            sudo sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons
+            sudo systemctl restart frr
+            # Check if FRR is active
+            if ! systemctl is-active --quiet frr; then
+                echo "FRR service did not start properly."
+                exit 1
+            fi
+        SHELL
+    
+    end
+  
+  
+    # Configure router2
+    config.vm.define "router2" do |router2|
+        router2.vm.box = "generic/ubuntu2204"
+        router2.vm.network "private_network", ip: "192.168.56.11"
+        router2.vm.hostname = "router2"
+        router2.vm.provision "shell", inline: <<-SHELL
+        # Disable systemd-resolved and set static DNS
+        sudo systemctl disable systemd-resolved
+        sudo systemctl stop systemd-resolved
+        sudo rm /etc/resolv.conf
+        echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+    
+        # Install FRR
+        sudo apt-get update
+        sudo apt-get install -y frr frr-doc
+        sudo sysctl -w net.ipv4.ip_forward=1
+        echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
+        SHELL
+    
+        # router1.vm.synced_folder "./config/router1/etc/frr", "/etc/frr"
+    
+        router2.vm.provision "shell", inline: <<-SHELL
+
+            sudo tee /etc/frr/frr.conf <<EOF
+!
+frr version 8.1
+frr defaults traditional
+hostname router2
+log syslog informational
+no ipv6 forwarding
+service integrated-vtysh-config
+!
+router bgp 65002
+    bgp router-id 192.168.56.11
+    neighbor 192.168.56.10 remote-as 65001
+    !
+    address-family ipv4 unicast
+    network 192.168.56.0/24
+    neighbor 192.168.56.10 soft-reconfiguration inbound
+    exit-address-family
+exit
+!
+end
+EOF
+
+            # Enable BGPD and restart FRR
+            sudo sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons
+            sudo systemctl restart frr
+            # Check if FRR is active
+            if ! systemctl is-active --quiet frr; then
+                echo "FRR service did not start properly."
+                exit 1
+            fi
+        SHELL
+    
+    end
+  end
+  


### PR DESCRIPTION
Това работи за мен.

2 DC router-a: router1, router2

FRR/BGP installed on both
BGP VPN configured

```shell
✔ ~/src/vagrants/frr-bgp-vpn-multisite [deploy-ovn-bgp-with-devstack|…1] $ vssh router2 -c "sudo vtysh -c 'show ip route'"
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/100] via 10.0.2.2, eth0, src 10.0.2.15, 00:02:08
C>* 10.0.2.0/24 [0/100] is directly connected, eth0, 00:02:08
K>* 10.0.2.2/32 [0/100] is directly connected, eth0, 00:02:08
K>* 10.0.2.3/32 [0/100] is directly connected, eth0, 00:02:08
C>* 192.168.56.0/24 is directly connected, eth1, 00:02:08
✔ ~/src/vagrants/frr-bgp-vpn-multisite [deploy-ovn-bgp-with-devstack|…1] $ vssh router1 -c "sudo vtysh -c 'show ip bgp summary'"

IPv4 Unicast Summary (VRF default):
BGP router identifier 192.168.56.10, local AS number 65001 vrf-id 0
BGP table version 1
RIB entries 1, using 184 bytes of memory
Peers 1, using 723 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.56.11   4      65002         5         5        0    0    0 00:02:18     (Policy) (Policy) N/A

Total number of neighbors 1

```